### PR TITLE
Remove extra column added by the transformer

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -263,6 +263,12 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String CONSISTENT_WRITES_DOC =
       "Whether to use consistency mode or not";
   private static final String CONSISTENT_WRITES_DISPLAY = "Consistent-Writes";
+  private static final String TABLE_IDENTIFIER_FIELD = "table.identifier.field";
+  private static final String REMOVE_TABLE_IDENTIFIER_FIELD = "remove.table.identifier.field";
+  private static final String REMOVE_TABLE_IDENTIFIER_FIELD_DEFAULT = "true";
+  private static final String TABLE_IDENTIFIER_FIELD_DEFAULT = "__dbz__physicalTableIdentifier";
+  private static final String TABLE_IDENTIFIER_FIELD_DOC =
+        "Table identifier field which needs to be removed if using consistency mode";
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
       EnumRecommender.in(QuoteMethod.values());
 
@@ -512,6 +518,22 @@ public class JdbcSinkConfig extends AbstractConfig {
           ConfigDef.Width.SHORT,
           CONSISTENT_WRITES_DISPLAY
         )
+        .define(
+          TABLE_IDENTIFIER_FIELD,
+          ConfigDef.Type.STRING,
+          TABLE_IDENTIFIER_FIELD_DEFAULT,
+          ConfigDef.Importance.LOW,
+          TABLE_IDENTIFIER_FIELD_DOC, "",
+          -1,
+          ConfigDef.Width.LONG,
+          CONSISTENT_WRITES_DISPLAY
+        )
+        .defineInternal(
+          REMOVE_TABLE_IDENTIFIER_FIELD,
+          ConfigDef.Type.BOOLEAN,
+          REMOVE_TABLE_IDENTIFIER_FIELD_DEFAULT,
+          ConfigDef.Importance.LOW
+        )
         .defineInternal(
             TRIM_SENSITIVE_LOG_ENABLED,
             ConfigDef.Type.BOOLEAN,
@@ -540,7 +562,8 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final TimeZone timeZone;
   public final EnumSet<TableType> tableTypes;
   public final boolean consistentWrites;
-
+  public final String tableIdentifierField;
+  public final boolean removeTableIdentifierField;
   public final boolean trimSensitiveLogsEnabled;
 
   public JdbcSinkConfig(Map<?, ?> props) {
@@ -572,6 +595,8 @@ public class JdbcSinkConfig extends AbstractConfig {
     }
     tableTypes = TableType.parse(getList(TABLE_TYPES_CONFIG));
     consistentWrites = getBoolean(CONSISTENT_WRITES);
+    tableIdentifierField = getString(TABLE_IDENTIFIER_FIELD);
+    removeTableIdentifierField = getBoolean(REMOVE_TABLE_IDENTIFIER_FIELD);
   }
 
   private String getPasswordValue(String key) {

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -34,9 +34,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
@@ -221,6 +219,57 @@ public class JdbcDbWriterTest {
     for (Field field : valueSchema2.fields()) {
       assertNotNull(refreshedMetadata.definitionForColumn(field.name()));
     }
+  }
+
+  @Test
+  public void removeTableIdentifierFieldWithConsistentWrites() throws SQLException {
+    String topic = "books";
+    TableId tableId = new TableId(null, null, topic);
+
+    Map<String, String> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", "true");
+    props.put("auto.evolve", "true");
+    props.put("pk.mode", "record_key");
+    props.put("pk.fields", "id");
+    props.put("consistent.writes", "true");
+
+    writer = newWriter(props);
+
+    Schema keySchema = Schema.INT64_SCHEMA;
+
+    Schema valueSchema1 = SchemaBuilder.struct()
+                            .field("author", Schema.STRING_SCHEMA)
+                            .field("title", Schema.STRING_SCHEMA)
+                            .field("__dbz_physicalTableIdentifier", Schema.STRING_SCHEMA)
+                            .build();
+
+    Struct valueStruct1 = new Struct(valueSchema1)
+                            .put("author", "Tom Robbins")
+                            .put("title", "Villa Incognito")
+                            .put("__dbz_physicalTableIdentifier", "books");
+
+    Schema txnSchema = SchemaBuilder.struct()
+                            .field("status", Schema.STRING_SCHEMA);
+    Struct beginStruct = new Struct(txnSchema).put("status", "BEGIN");
+
+    Struct endStruct = new Struct(txnSchema).put("status", "BEGIN");
+
+    List<SinkRecord> records = new ArrayList<>();
+    records.add(new SinkRecord(topic, 0, keySchema, 0L, txnSchema, beginStruct, 0));
+    records.add(new SinkRecord(topic, 0, keySchema, 1L, valueSchema1, valueStruct1, 1));
+    records.add(new SinkRecord(topic, 0, keySchema, 2L, txnSchema, endStruct, 2));
+    writer.writeConsistently(records);
+
+    assertEquals(
+      1,
+      sqliteHelper.select("select count(*) from books", new SqliteHelper.ResultSetReadCallback() {
+        @Override
+        public void read(ResultSet rs) throws SQLException {
+          assertEquals(1, rs.getInt(1));
+        }
+      })
+    );
   }
 
   @Test(expected = SQLException.class)

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -247,7 +247,7 @@ public class JdbcDbWriterTest {
                             .field("__dbz_physicalTableIdentifier", Schema.STRING_SCHEMA)
                             .build();
 
-    Struct valueStruct = new Struct(valueSchema1)
+    Struct valueStruct = new Struct(valueSchema)
                             .put("author", "Tom Robbins")
                             .put("title", "Villa Incognito")
                             .put("__dbz_physicalTableIdentifier", "books");

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -271,6 +271,13 @@ public class JdbcDbWriterTest {
         @Override
         public void read(ResultSet rs) throws SQLException {
           assertEquals(1, rs.getInt(1));
+
+          // Also assert that there is no field named __dbz_physicalTableIdentifier
+          try {
+            rs.getString("__dbz_physicalTableIdentifier");
+          } catch (SQLException sqle) {
+            assertTrue(sqle.getMessage().contains("no such column: '__dbz_physicalTableIdentifier'"));
+          }
         }
       })
     );


### PR DESCRIPTION
## Problem
When we send all the records to a common topic and add another transformer in the sink to extract those records i.e. `io.aiven.kafka.connect.transforms.ExtractTopic$Key` then a field is added in the record under the name `__dbz_physicalTableIdentifier` - this causes a mismatch in the structure of the record and the structure of the target tables.

## Solution
To avoid the above mentioned problem, while processing each record, we are modifying it and removing the extra added column.

### Added config properties
* `table.identifier.field` - the name of the field to be removed, default: `__dbz_physicalTableIdentifier`
* `remove.table.identifier.field` - whether or not to remove this field, default: `true`

### Considerations
* This solution will only work when `consistent.writes` is enabled i.e. set to a `true` value
