### PR TITLE
Fix NullPointerException while processing tombstone records

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -27,7 +27,6 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -27,6 +27,7 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
@@ -177,6 +178,11 @@ public class JdbcDbWriter {
    * @return updated schema with the field removed
    */
   Schema makeUpdatedSchema(Schema schema) {
+    // This pre-check is for tombstone records where do not have a value schema for them.
+    if (schema == null) {
+      return null;
+    }
+
     SchemaBuilder builder = SchemaBuilder.struct();
 
     for (Field field : schema.fields()) {
@@ -197,6 +203,11 @@ public class JdbcDbWriter {
    * @return a modified struct with the removed value
    */
   Struct makeUpdatedStruct(Schema schema, Struct value) {
+    // Pre-check for tombstone records: exit early if schema or value is found to be null.
+    if (schema == null || value == null) {
+      return null;
+    }
+
     Struct updated = new Struct(schema);
 
     for (Field field : value.schema().fields()) {

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -281,16 +281,62 @@ public class JdbcDbWriterTest {
         }
       })
     );
+  }
+
+  @Test
+  public void removeTableIdentifierWithTombstoneRecords() throws SQLException {
+    String topic = "books";
+    TableId tableId = new TableId(null, null, topic);
+
+    Map<String, String> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", "true");
+    props.put("auto.evolve", "true");
+    props.put("pk.mode", "record_key");
+    props.put("pk.fields", "id");
+    props.put("consistent.writes", "true");
+    props.put("delete.enabled", "true");
+
+    writer = newWriter(props);
+
+    Schema keySchema = SchemaBuilder.struct()
+                         .field("id", Schema.INT32_SCHEMA);
+    Struct keyStruct = new Struct(keySchema)
+                         .put("id", 1);
+
+    Schema valueSchema = SchemaBuilder.struct()
+                           .field("author", Schema.STRING_SCHEMA)
+                           .field("title", Schema.STRING_SCHEMA)
+                           .field("__dbz_physicalTableIdentifier", Schema.STRING_SCHEMA)
+                           .build();
+
+    Struct valueStruct = new Struct(valueSchema)
+                           .put("author", "Tom Robbins")
+                           .put("title", "Villa Incognito")
+                           .put("__dbz_physicalTableIdentifier", "books");
+
+    Schema txnSchema = SchemaBuilder.struct()
+                         .field("status", Schema.STRING_SCHEMA);
+    Struct beginStruct = new Struct(txnSchema).put("status", "BEGIN");
+
+    Struct endStruct = new Struct(txnSchema).put("status", "END");
+
+    // Put the same schema and value in transactional records for ease of use.
+    List<SinkRecord> records = new ArrayList<>();
+    records.add(new SinkRecord(topic, 0, txnSchema, beginStruct, txnSchema, beginStruct, 0));
+    records.add(new SinkRecord(topic, 0, keySchema, keyStruct, valueSchema, valueStruct, 1));
+    records.add(new SinkRecord(topic, 0, txnSchema, endStruct, txnSchema, endStruct, 2));
+    writer.writeConsistently(records);
 
     // Verify that the writer handles tombstone records gracefully as well.
     List<SinkRecord> deleteRecords = new ArrayList<>();
     deleteRecords.add(new SinkRecord(topic, 0, txnSchema, beginStruct, txnSchema, beginStruct, 3));
-    deleteRecords.add(new SinkRecord(topic, 0, keySchema, keyStruct, valueSchema, valueStruct, 4));
-    deleteRecords.add(new SinkRecord(topic, 0, keySchema, keyStruct, null, null, 5));
-    deleteRecords.add(new SinkRecord(topic, 0, txnSchema, endStruct, txnSchema, endStruct, 6));
+    deleteRecords.add(new SinkRecord(topic, 0, keySchema, keyStruct, null, null, 4));
+    deleteRecords.add(new SinkRecord(topic, 0, txnSchema, endStruct, txnSchema, endStruct, 5));
+    writer.writeConsistently(deleteRecords);
 
     assertEquals(
-      0,
+      1,
       sqliteHelper.select("select count(*) from books", new SqliteHelper.ResultSetReadCallback() {
         @Override
         public void read(ResultSet rs) throws SQLException {

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -281,6 +281,23 @@ public class JdbcDbWriterTest {
         }
       })
     );
+
+    // Verify that the writer handles tombstone records gracefully as well.
+    List<SinkRecord> deleteRecords = new ArrayList<>();
+    deleteRecords.add(new SinkRecord(topic, 0, txnSchema, beginStruct, txnSchema, beginStruct, 3));
+    deleteRecords.add(new SinkRecord(topic, 0, keySchema, keyStruct, valueSchema, valueStruct, 4));
+    deleteRecords.add(new SinkRecord(topic, 0, keySchema, keyStruct, null, null, 5));
+    deleteRecords.add(new SinkRecord(topic, 0, txnSchema, endStruct, txnSchema, endStruct, 6));
+
+    assertEquals(
+      0,
+      sqliteHelper.select("select count(*) from books", new SqliteHelper.ResultSetReadCallback() {
+        @Override
+        public void read(ResultSet rs) throws SQLException {
+          assertEquals(0, rs.getInt(1));
+        }
+      })
+    );
   }
 
   @Test(expected = SQLException.class)


### PR DESCRIPTION
## Problem
While processing tombstone records, the connector was throwing an error of `NullPointerException` which was because of the fact that tombstone records have `null` schema and value. The stacktrace reported was:

```
org.apache.kafka.connect.errors.ConnectException: Exiting WorkerSinkTask due to unrecoverable exception.
at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:611) org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:333)
at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:234)
at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:203)
at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:188)
at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:243)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
at java.base/java.lang.Thread.run(Thread.java:829)

Caused by: java.lang.NullPointerException
at io.confluent.connect.jdbc.sink.JdbcDbWriter.makeUpdatedSchema(JdbcDbWriter.java:182)
at io.confluent.connect.jdbc.sink.JdbcDbWriter.removeTableIdentifierField(JdbcDbWriter.java:164)
at io.confluent.connect.jdbc.sink.JdbcDbWriter.writeConsistently(JdbcDbWriter.java:134)
at io.confluent.connect.jdbc.sink.JdbcSinkTask.put(JdbcSinkTask.java:92)
at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:581)
```

## Solution
Ignore processing any schema or struct if the value is found to be null.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no
